### PR TITLE
Setting up the environment: Update `cosmwasm-check` example output

### DIFF
--- a/src/setting-up-env.md
+++ b/src/setting-up-env.md
@@ -47,7 +47,7 @@ If the installation succeeds, you should be able to execute the utility from you
 
 ```
 $ cosmwasm-check --version
-Contract checking 1.1.0
+Contract checking 1.2.3
 ```
 
 ## Verifying the installation
@@ -80,7 +80,10 @@ of the root repo directory - not in the contract directory itself! Now you can c
 validation passes:
 
 ```
-cw-plus $ cosmwasm-check ../../target/wasm32-unknown-unknown/release/cw1_whitelist.wasm
-Supported features: {"stargate", "iterator", "staking"}
-contract checks passed.
+cw-plus/contracts/cw1-whitelist $ cosmwasm-check ../../target/wasm32-unknown-unknown/release/cw1_whitelist.wasm
+Available capabilities: {"iterator", "cosmwasm_1_1", "cosmwasm_1_2", "stargate", "staking"}
+
+../../target/wasm32-unknown-unknown/release/cw1_whitelist.wasm: pass
+
+All contracts (1) passed checks!
 ```


### PR DESCRIPTION
### Change Details
This change updated the example output of `cosmwasm-check` examples in the "check contract utility" and "verifying installation" sections. 

For "Check contract utility":
  - Updated version to latest stable (version 1.2.3)

For "Verifying Installation", Two issues were fixed:

1. The filepath for cw1_whitelist didn't match the current directory in the example. Updated current directory to be in the same place where `cargo wasm` was run.
2. My local output of `cosmwasm-check` was different from the documentation, likely due to version. Updating documentation to be consistent with version change.

### My local console output:
```
ori@Arborea:~/code/cw-plus/contracts/cw1-whitelist$ cosmwasm-check ../../target/wasm32-unknown-unknown/release/cw1_whitelist.wasm
Available capabilities: {"iterator", "cosmwasm_1_1", "cosmwasm_1_2", "stargate", "staking"}

../../target/wasm32-unknown-unknown/release/cw1_whitelist.wasm: pass

All contracts (1) passed checks!
ori@Arborea:~/code/cw-plus/contracts/cw1-whitelist$ cosmwasm-check --version
Contract checking 1.2.3
```
