### PR TITLE
3.3 Building the contract: example should call `cosmwasm-check`

### DIFF
--- a/src/basics/building-contract.md
+++ b/src/basics/building-contract.md
@@ -50,7 +50,8 @@ When the contract is built, the last step is to ensure it is a valid CosmWasm co
 ```
 $ cargo wasm
 ...
-$ check_contract ./target/wasm32-unknown-unknown/release/contract.wasm
-Supported features: {"iterator", "staking", "stargate"}
-contract checks passed.
+$ cosmwasm-check ./target/wasm32-unknown-unknown/release/contract.wasm
+Available capabilities: {"cosmwasm_1_1", "staking", "stargate", "iterator", "cosmwasm_1_2"}
+
+./target/wasm32-unknown-unknown/release/contract.wasm: pass
 ```


### PR DESCRIPTION
### Description
This change fixes the example cli output for the "checking-contract-validity" section. Originally the example called `check_contract`, which isn't a valid command. This change updates it to use `cosmwasm-check`.

Updated the output of `cosmwasm-check` as well.

### local dev output 
```
ori@Arborea:~/code/cosmwasm_tutorial$ check_contract ./target/wasm32-unknown-unknown/release/cosmwasm_tutorial.wasm
check_contract: command not found
ori@Arborea:~/code/cosmwasm_tutorial$ cosmwasm-check ./target/wasm32-unknown-unknown/release/cosmwasm_tutorial.wasm
Available capabilities: {"cosmwasm_1_1", "staking", "stargate", "iterator", "cosmwasm_1_2"}

./target/wasm32-unknown-unknown/release/cosmwasm_tutorial.wasm: pass

All contracts (1) passed checks!
ori@Arborea:~/code/cosmwasm_tutorial$
```
